### PR TITLE
fix yaml property comparator

### DIFF
--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/util/YamlPropertyComparator.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/util/YamlPropertyComparator.java
@@ -18,7 +18,13 @@ public class YamlPropertyComparator implements Comparator<Property> {
         if (fieldOrder.contains(o1.getName()) && fieldOrder.contains(o2.getName())) {
             return fieldOrder.indexOf(o1.getName()) > fieldOrder.indexOf(o2.getName()) ? 1 : -1;
         }
-        return o1.getName()
-            .compareTo(o2.getName());
+        if (!fieldOrder.contains(o1.getName()) && !fieldOrder.contains(o2.getName())) {
+            return o1.getName()
+                .compareTo(o2.getName());
+        }
+        if (fieldOrder.contains(o1.getName())) {
+            return -1;
+        }
+        return 1;
     }
 }


### PR DESCRIPTION
fix yaml property comparator when one property is in the fieldOrder and
the other isn't.