### PR TITLE
Builders create default Metadata

### DIFF
--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/Metadata.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/Metadata.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.lm.sl.mta.model;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -14,6 +15,8 @@ public class Metadata {
     private static final String SENSITIVE = "sensitive";
 
     private Map<String, Map<String, Object>> metadata;
+
+    public static final Metadata DEFAULT_METADATA = new Metadata(Collections.<String, Map<String, Object>> emptyMap());
 
     public Metadata(Map<String, Map<String, Object>> metadata) {
         this.metadata = metadata;

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/DeploymentDescriptor.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/DeploymentDescriptor.java
@@ -119,7 +119,7 @@ public class DeploymentDescriptor extends com.sap.cloud.lm.sl.mta.model.v2.Deplo
             result.setModules3(ObjectUtils.defaultIfNull(modules3, Collections.<Module> emptyList()));
             result.setResources3(ObjectUtils.defaultIfNull(resources3, Collections.<Resource> emptyList()));
             result.setParameters(ObjectUtils.defaultIfNull(parameters, Collections.<String, Object> emptyMap()));
-            result.setParametersMetadata(parametersMetadata);
+            result.setParametersMetadata(ObjectUtils.defaultIfNull(parametersMetadata, Metadata.DEFAULT_METADATA));
             return result;
         }
 

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/Module.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/Module.java
@@ -133,8 +133,8 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
                 ObjectUtils.defaultIfNull(requiredDependencies3, Collections.<RequiredDependency> emptyList()));
             result.setProvidedDependencies3(
                 ObjectUtils.defaultIfNull(providedDependencies3, Collections.<ProvidedDependency> emptyList()));
-            result.setPropertiesMetadata(propertiesMetadata);
-            result.setParametersMetadata(parametersMetadata);
+            result.setPropertiesMetadata(ObjectUtils.defaultIfNull(propertiesMetadata, Metadata.DEFAULT_METADATA));
+            result.setParametersMetadata(ObjectUtils.defaultIfNull(parametersMetadata, Metadata.DEFAULT_METADATA));
             return result;
         }
 

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/ProvidedDependency.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/ProvidedDependency.java
@@ -84,9 +84,9 @@ public class ProvidedDependency extends com.sap.cloud.lm.sl.mta.model.v2.Provide
             result.setName(name);
             result.setPublic(ObjectUtils.defaultIfNull(isPublic, false));
             result.setProperties(ObjectUtils.defaultIfNull(properties, Collections.<String, Object> emptyMap()));
-            result.setPropertiesMetadata(propertiesMetadata);
+            result.setPropertiesMetadata(ObjectUtils.defaultIfNull(propertiesMetadata, Metadata.DEFAULT_METADATA));
             result.setParameters(ObjectUtils.defaultIfNull(parameters, Collections.<String, Object> emptyMap()));
-            result.setParametersMetadata(parametersMetadata);
+            result.setParametersMetadata(ObjectUtils.defaultIfNull(parametersMetadata, Metadata.DEFAULT_METADATA));
             return result;
         }
 

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/RequiredDependency.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/RequiredDependency.java
@@ -72,8 +72,8 @@ public class RequiredDependency extends com.sap.cloud.lm.sl.mta.model.v2.Require
             result.setList(list);
             result.setProperties(ObjectUtils.defaultIfNull(properties, Collections.<String, Object> emptyMap()));
             result.setParameters(ObjectUtils.defaultIfNull(parameters, Collections.<String, Object> emptyMap()));
-            result.setPropertiesMetadata(propertiesMetadata);
-            result.setParametersMetadata(parametersMetadata);
+            result.setPropertiesMetadata(ObjectUtils.defaultIfNull(propertiesMetadata, Metadata.DEFAULT_METADATA));
+            result.setParametersMetadata(ObjectUtils.defaultIfNull(parametersMetadata, Metadata.DEFAULT_METADATA));
             return result;
         }
 

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/Resource.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/Resource.java
@@ -129,8 +129,8 @@ public class Resource extends com.sap.cloud.lm.sl.mta.model.v2.Resource
             result.setDescription(description);
             result.setProperties(ObjectUtils.defaultIfNull(properties, Collections.<String, Object> emptyMap()));
             result.setParameters(ObjectUtils.defaultIfNull(parameters, Collections.<String, Object> emptyMap()));
-            result.setPropertiesMetadata(propertiesMetadata);
-            result.setParametersMetadata(parametersMetadata);
+            result.setPropertiesMetadata(ObjectUtils.defaultIfNull(propertiesMetadata, Metadata.DEFAULT_METADATA));
+            result.setParametersMetadata(ObjectUtils.defaultIfNull(parametersMetadata, Metadata.DEFAULT_METADATA));
             result.setRequiredDependencies3(
                 ObjectUtils.defaultIfNull(requiredDependencies3, Collections.<RequiredDependency> emptyList()));
             result.setOptional(ObjectUtils.defaultIfNull(isOptional, false));


### PR DESCRIPTION
#### Description: 
The flow for creation of MTA model objects is Parser->Builder.
Previously only the Parser was creating default Metadata
for MTA objects, which leads to NPE when use only Builder
to create MTA object. Now also Builders are creating default
Metadata.

JIRA: NGPBUG-68974