### PR TITLE
Introduce new 'deployed-after' attribute

### DIFF
--- a/com.sap.cloud.lm.sl.common/src/main/java/com/sap/cloud/lm/sl/common/util/DigestHelper.java
+++ b/com.sap.cloud.lm.sl.common/src/main/java/com/sap/cloud/lm/sl/common/util/DigestHelper.java
@@ -14,6 +14,15 @@ public class DigestHelper {
 
     private static final int BUFFER_SIZE = 4 * 1024;
 
+    public static String appendDigests(String digest, String additionalDigest, String digestAlgorithm) throws NoSuchAlgorithmException {
+        byte[] fileChecksum = DatatypeConverter.parseHexBinary(digest);
+        byte[] additionalFileChecksum = DatatypeConverter.parseHexBinary(additionalDigest);
+        MessageDigest md = MessageDigest.getInstance(digestAlgorithm);
+        md.update(fileChecksum);
+        md.update(additionalFileChecksum);
+        return DatatypeConverter.printHexBinary(md.digest());
+    }
+
     public static String computeFileChecksum(Path file, String algorithm) throws NoSuchAlgorithmException, IOException {
         return DatatypeConverter.printHexBinary(computeFileCheckSumBytes(file, algorithm));
     }

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/builders/v1/ModuleDependenciesCollector.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/builders/v1/ModuleDependenciesCollector.java
@@ -1,0 +1,78 @@
+package com.sap.cloud.lm.sl.mta.builders.v1;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.sap.cloud.lm.sl.mta.handlers.v1.DescriptorHandler;
+import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+
+public class ModuleDependenciesCollector {
+
+    private DescriptorHandler handler;
+    protected DeploymentDescriptor descriptor;
+    protected Set<String> seenModules = new HashSet<>();
+
+    public ModuleDependenciesCollector(DeploymentDescriptor descriptor, DescriptorHandler handler) {
+        this.descriptor = descriptor;
+        this.handler = handler;
+    }
+
+    public Set<String> collect(Module module) {
+        clearVisitedModules();
+        return getDependenciesRecursively(module);
+    }
+
+    private void clearVisitedModules() {
+        seenModules.clear();
+    }
+
+    private Set<String> getDependenciesRecursively(Module module) {
+        if (visited(module)) {
+            return Collections.emptySet();
+        }
+        markVisited(module);
+        return collectDependenciesRecursively(module);
+    }
+
+    private boolean visited(Module module) {
+        return seenModules.contains(module.getName());
+    }
+
+    private void markVisited(Module module) {
+        seenModules.add(module.getName());
+    }
+
+    private Set<String> collectDependenciesRecursively(Module module) {
+        Set<String> dependencies = new LinkedHashSet<>();
+        for (String dependency : getDependencies(module)) {
+            Module moduleProvidingDependency = findModuleSatisfyingDependency(dependency);
+            if (notRequiresSelf(module, moduleProvidingDependency)) {
+                dependencies.add(moduleProvidingDependency.getName());
+                dependencies.addAll(getDependenciesRecursively(moduleProvidingDependency));
+            }
+        }
+        return dependencies;
+    }
+
+    protected List<String> getDependencies(Module module) {
+        return module.getRequiredDependencies1();
+    }
+
+    protected Module findModuleSatisfyingDependency(String dependency) {
+        return descriptor.getModules1()
+            .stream()
+            .filter(module -> handler.findProvidedDependency(module, dependency) != null)
+            .findFirst()
+            .orElse(null);
+    }
+
+    private boolean notRequiresSelf(Module module, Module requiredModule) {
+        return requiredModule != null && !requiredModule.getName()
+            .equals(module.getName());
+    }
+
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/builders/v2/ModuleDependenciesCollector.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/builders/v2/ModuleDependenciesCollector.java
@@ -1,0 +1,27 @@
+package com.sap.cloud.lm.sl.mta.builders.v2;
+
+import static com.sap.cloud.lm.sl.common.util.CommonUtil.cast;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.sap.cloud.lm.sl.mta.handlers.v1.DescriptorHandler;
+import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+import com.sap.cloud.lm.sl.mta.model.v2.RequiredDependency;
+
+public class ModuleDependenciesCollector extends com.sap.cloud.lm.sl.mta.builders.v1.ModuleDependenciesCollector {
+
+    public ModuleDependenciesCollector(DeploymentDescriptor descriptor, DescriptorHandler handler) {
+        super(descriptor, handler);
+    }
+
+    @Override
+    protected List<String> getDependencies(Module module) {
+        com.sap.cloud.lm.sl.mta.model.v2.Module moduleV2 = cast(module);
+        return moduleV2.getRequiredDependencies2()
+            .stream()
+            .map(RequiredDependency::getName)
+            .collect(Collectors.toList());
+    }
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/builders/v3/ModuleDependenciesCollector.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/builders/v3/ModuleDependenciesCollector.java
@@ -1,0 +1,45 @@
+package com.sap.cloud.lm.sl.mta.builders.v3;
+
+import static com.sap.cloud.lm.sl.common.util.CommonUtil.cast;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.ListUtils;
+
+import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+
+public class ModuleDependenciesCollector extends com.sap.cloud.lm.sl.mta.builders.v2.ModuleDependenciesCollector {
+
+    public ModuleDependenciesCollector(DeploymentDescriptor descriptor) {
+        super(descriptor, null);
+    }
+
+    @Override
+    public Set<String> collect(Module module) {
+        Set<String> collectedDependencies = super.collect(module);
+        com.sap.cloud.lm.sl.mta.model.v3.Module moduleV3 = cast(module);
+        List<String> deployedAfter = collectedDependencies.stream()
+            .collect(Collectors.toList());
+        moduleV3.setDeployedAfter(deployedAfter);
+        return collectedDependencies;
+    }
+
+    @Override
+    protected List<String> getDependencies(Module module) {
+        com.sap.cloud.lm.sl.mta.model.v3.Module moduleV3 = cast(module);
+        return ListUtils.emptyIfNull(moduleV3.getDeployedAfter());
+    }
+
+    @Override
+    protected Module findModuleSatisfyingDependency(String dependency) {
+        return descriptor.getModules1()
+            .stream()
+            .filter(module -> module.getName()
+                .equals(dependency))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/ModulesSorter.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/ModulesSorter.java
@@ -1,0 +1,10 @@
+package com.sap.cloud.lm.sl.mta.handlers;
+
+import java.util.List;
+
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+
+public interface ModulesSorter {
+
+    List<? extends Module> sort();
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v1/ModuleComparator.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v1/ModuleComparator.java
@@ -3,13 +3,13 @@ package com.sap.cloud.lm.sl.mta.handlers.v1;
 import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
-import com.sap.cloud.lm.sl.common.util.Pair;
 import com.sap.cloud.lm.sl.mta.message.Messages;
 import com.sap.cloud.lm.sl.mta.model.v1.Module;
 
-public class ModuleComparator implements Comparator<Pair<Module, Set<String>>> {
+public class ModuleComparator implements Comparator<Entry<Module, Set<String>>> {
 
     private final String dependencyTypeProperty;
     private final String hardDependencyType;
@@ -20,13 +20,14 @@ public class ModuleComparator implements Comparator<Pair<Module, Set<String>>> {
     }
 
     @Override
-    public int compare(Pair<Module, Set<String>> modulePair1, Pair<Module, Set<String>> modulePair2) {
-        Module module1 = modulePair1._1;
-        Module module2 = modulePair2._1;
+    public int compare(Entry<Module, Set<String>> pair1, Entry<Module, Set<String>> pair2) {
+        Module module1 = pair1.getKey();
+        Set<String> module1Dependencies = pair1.getValue();
         String dependencyTypeModule1 = (String) getPropertyValue(module1, dependencyTypeProperty);
+
+        Module module2 = pair2.getKey();
+        Set<String> module2Dependencies = pair2.getValue();
         String dependencyTypeModule2 = (String) getPropertyValue(module2, dependencyTypeProperty);
-        Set<String> module1Dependencies = modulePair1._2;
-        Set<String> module2Dependencies = modulePair2._2;
 
         if (circularDependencyExists(module1.getName(), module1Dependencies, module2.getName(), module2Dependencies)) {
             if (hardDependencyType.equals(dependencyTypeModule1) && hardDependencyType.equals(dependencyTypeModule2)) {

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v1/ModulesSorter.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v1/ModulesSorter.java
@@ -1,0 +1,64 @@
+package com.sap.cloud.lm.sl.mta.handlers.v1;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.sap.cloud.lm.sl.mta.builders.v1.ModuleDependenciesCollector;
+import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+
+public class ModulesSorter implements com.sap.cloud.lm.sl.mta.handlers.ModulesSorter {
+
+    protected DeploymentDescriptor descriptor;
+    protected DescriptorHandler handler;
+    protected String dependencyTypeProperty;
+    protected String hardDependencyType;
+
+    public ModulesSorter(DeploymentDescriptor descriptor, DescriptorHandler handler, String dependencyTypeProperty,
+        String hardDependencyType) {
+        this.descriptor = descriptor;
+        this.handler = handler;
+        this.dependencyTypeProperty = dependencyTypeProperty;
+        this.hardDependencyType = hardDependencyType;
+    }
+
+    public List<? extends Module> sort() {
+        Map<Module, Set<String>> modulesAndDeploymentDependencies = getModulesAndDeploymentDependencies();
+        List<Entry<Module, Set<String>>> modulesAndDeploymentDependenciesSorted = modulesAndDeploymentDependencies.entrySet()
+            .stream()
+            .collect(Collectors.toList());
+
+        Collections.sort(modulesAndDeploymentDependenciesSorted, getModuleComparator(dependencyTypeProperty, hardDependencyType));
+
+        return modulesAndDeploymentDependenciesSorted.stream()
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
+    }
+
+    protected Map<Module, Set<String>> getModulesAndDeploymentDependencies() {
+        Map<Module, Set<String>> result = new LinkedHashMap<>();
+        for (Module module : descriptor.getModules1()) {
+            result.put(module, getDependencies(module));
+        }
+        return result;
+    }
+
+    protected Set<String> getDependencies(Module module) {
+        return getDependenciesCollector().collect(module);
+    }
+
+    protected ModuleDependenciesCollector getDependenciesCollector() {
+        return new ModuleDependenciesCollector(descriptor, handler);
+    }
+
+    protected Comparator<Entry<Module, Set<String>>> getModuleComparator(String dependencyTypeProperty, String hardDependencyType) {
+        return new ModuleComparator(dependencyTypeProperty, hardDependencyType);
+    }
+
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v2/DescriptorHandler.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v2/DescriptorHandler.java
@@ -1,9 +1,6 @@
 package com.sap.cloud.lm.sl.mta.handlers.v2;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.sap.cloud.lm.sl.mta.handlers.v1.ModuleComparator;
+import com.sap.cloud.lm.sl.mta.handlers.ModulesSorter;
 import com.sap.cloud.lm.sl.mta.model.v2.DeploymentDescriptor;
 import com.sap.cloud.lm.sl.mta.model.v2.ExtensionDescriptor;
 import com.sap.cloud.lm.sl.mta.model.v2.ExtensionModule;
@@ -12,15 +9,6 @@ import com.sap.cloud.lm.sl.mta.model.v2.Module;
 import com.sap.cloud.lm.sl.mta.model.v2.RequiredDependency;
 
 public class DescriptorHandler extends com.sap.cloud.lm.sl.mta.handlers.v1.DescriptorHandler {
-
-    @Override
-    protected List<String> getRequiredDependencyNames(com.sap.cloud.lm.sl.mta.model.v1.Module module) {
-        List<String> names = new ArrayList<>();
-        for (RequiredDependency dependency : ((Module) module).getRequiredDependencies2()) {
-            names.add(dependency.getName());
-        }
-        return names;
-    }
 
     public RequiredDependency findRequiredDependency(DeploymentDescriptor descriptor, String moduleName, String dependencyName) {
         for (Module module : descriptor.getModules2()) {
@@ -63,8 +51,9 @@ public class DescriptorHandler extends com.sap.cloud.lm.sl.mta.handlers.v1.Descr
     }
 
     @Override
-    protected ModuleComparator getModuleComparator(String dependencyTypeProperty, String hardDependencyType) {
-        return new com.sap.cloud.lm.sl.mta.handlers.v2.ModuleComparator(dependencyTypeProperty, hardDependencyType);
+    protected ModulesSorter getModuleSorter(com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor descriptor,
+        String parallelDeploymentProperty, String dependencyTypeProperty, String hardDependencyType) {
+        return new com.sap.cloud.lm.sl.mta.handlers.v2.ModulesSorter(descriptor, this, dependencyTypeProperty, hardDependencyType);
     }
 
 }

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v2/ModulesSorter.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v2/ModulesSorter.java
@@ -1,0 +1,25 @@
+package com.sap.cloud.lm.sl.mta.handlers.v2;
+
+import java.util.Comparator;
+
+import com.sap.cloud.lm.sl.mta.builders.v2.ModuleDependenciesCollector;
+import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
+
+public class ModulesSorter extends com.sap.cloud.lm.sl.mta.handlers.v1.ModulesSorter {
+
+    public ModulesSorter(DeploymentDescriptor descriptor, DescriptorHandler handler, String dependencyTypeProperty,
+        String hardDependencyType) {
+        super(descriptor, handler, dependencyTypeProperty, hardDependencyType);
+    }
+
+    @Override
+    protected ModuleDependenciesCollector getDependenciesCollector() {
+        return new ModuleDependenciesCollector(descriptor, handler);
+    }
+
+    @Override
+    protected Comparator getModuleComparator(String dependencyTypeProperty, String hardDependencyType) {
+        return new ModuleComparator(dependencyTypeProperty, hardDependencyType);
+    }
+
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/DescriptorHandler.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/DescriptorHandler.java
@@ -2,8 +2,9 @@ package com.sap.cloud.lm.sl.mta.handlers.v3;
 
 import static com.sap.cloud.lm.sl.common.util.CommonUtil.cast;
 
-import com.sap.cloud.lm.sl.mta.model.v2.DeploymentDescriptor;
-import com.sap.cloud.lm.sl.mta.model.v2.ExtensionDescriptor;
+import com.sap.cloud.lm.sl.mta.handlers.ModulesSorter;
+import com.sap.cloud.lm.sl.mta.model.v3.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.v3.ExtensionDescriptor;
 import com.sap.cloud.lm.sl.mta.model.v3.ExtensionRequiredDependency;
 import com.sap.cloud.lm.sl.mta.model.v3.ExtensionResource;
 import com.sap.cloud.lm.sl.mta.model.v3.RequiredDependency;
@@ -12,12 +13,13 @@ import com.sap.cloud.lm.sl.mta.model.v3.Resource;
 public class DescriptorHandler extends com.sap.cloud.lm.sl.mta.handlers.v2.DescriptorHandler {
 
     @Override
-    public RequiredDependency findRequiredDependency(DeploymentDescriptor descriptor, String consumerName, String dependencyName) {
+    public RequiredDependency findRequiredDependency(com.sap.cloud.lm.sl.mta.model.v2.DeploymentDescriptor descriptor, String consumerName,
+        String dependencyName) {
         RequiredDependency moduleRequireDependency = cast(super.findRequiredDependency(descriptor, consumerName, dependencyName));
         if (moduleRequireDependency != null) {
             return moduleRequireDependency;
         }
-        com.sap.cloud.lm.sl.mta.model.v3.DeploymentDescriptor descriptorV3 = cast(descriptor);
+        DeploymentDescriptor descriptorV3 = cast(descriptor);
         for (Resource resource : descriptorV3.getResources3()) {
             if (resource.getName()
                 .equals(consumerName)) {
@@ -28,12 +30,13 @@ public class DescriptorHandler extends com.sap.cloud.lm.sl.mta.handlers.v2.Descr
     }
 
     @Override
-    public ExtensionRequiredDependency findRequiredDependency(ExtensionDescriptor descriptor, String consumerName, String dependencyName) {
+    public ExtensionRequiredDependency findRequiredDependency(com.sap.cloud.lm.sl.mta.model.v2.ExtensionDescriptor descriptor,
+        String consumerName, String dependencyName) {
         ExtensionRequiredDependency moduleRequireDependency = cast(super.findRequiredDependency(descriptor, consumerName, dependencyName));
         if (moduleRequireDependency != null) {
             return moduleRequireDependency;
         }
-        com.sap.cloud.lm.sl.mta.model.v3.ExtensionDescriptor descriptorV3 = cast(descriptor);
+        ExtensionDescriptor descriptorV3 = cast(descriptor);
         for (ExtensionResource resource : descriptorV3.getResources3()) {
             if (resource.getName()
                 .equals(consumerName)) {
@@ -62,4 +65,13 @@ public class DescriptorHandler extends com.sap.cloud.lm.sl.mta.handlers.v2.Descr
         }
         return null;
     }
+
+    @Override
+    protected ModulesSorter getModuleSorter(com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor descriptor,
+        String parallelDeploymentProperty, String dependencyTypeProperty, String hardDependencyType) {
+        DeploymentDescriptor descriptorV3 = cast(descriptor);
+        return new com.sap.cloud.lm.sl.mta.handlers.v3.ModulesSorter(descriptorV3, this, dependencyTypeProperty, hardDependencyType,
+            parallelDeploymentProperty);
+    }
+
 }

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/ModuleComparator.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/ModuleComparator.java
@@ -1,0 +1,35 @@
+package com.sap.cloud.lm.sl.mta.handlers.v3;
+
+import java.text.MessageFormat;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.commons.collections4.ListUtils;
+
+import com.sap.cloud.lm.sl.mta.message.Messages;
+import com.sap.cloud.lm.sl.mta.model.v3.Module;
+
+public class ModuleComparator implements Comparator<Module> {
+
+    @Override
+    public int compare(Module module1, Module module2) {
+        List<String> module1DeployedAfter = ListUtils.emptyIfNull(module1.getDeployedAfter());
+        List<String> module2DeployedAfter = ListUtils.emptyIfNull(module2.getDeployedAfter());
+        if (circularDependencyExists(module1.getName(), module2.getName(), module1DeployedAfter, module2DeployedAfter)) {
+            throw new IllegalStateException(
+                MessageFormat.format(Messages.CIRCULAR_DEPLOYMENT_DEPENDENCIES_DETECTED, module1.getName(), module2.getName()));
+        }
+        if (module1DeployedAfter.contains(module2.getName())) {
+            return +1;
+        }
+        if (module2DeployedAfter.contains(module1.getName())) {
+            return -1;
+        }
+        return +0;
+    }
+
+    private boolean circularDependencyExists(String module1Name, String module2Name, List<String> module1DeployedAfter,
+        List<String> module2DeployedAfter) {
+        return module1DeployedAfter.contains(module2Name) && module2DeployedAfter.contains(module1Name);
+    }
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/ModulesSorter.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/ModulesSorter.java
@@ -1,0 +1,84 @@
+package com.sap.cloud.lm.sl.mta.handlers.v3;
+
+import static com.sap.cloud.lm.sl.common.util.CommonUtil.cast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import com.sap.cloud.lm.sl.mta.builders.v2.ModuleDependenciesCollector;
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+import com.sap.cloud.lm.sl.mta.model.v3.DeploymentDescriptor;
+
+public class ModulesSorter extends com.sap.cloud.lm.sl.mta.handlers.v2.ModulesSorter {
+
+    String parallelDeploymentsProperty;
+
+    public ModulesSorter(DeploymentDescriptor descriptor, DescriptorHandler handler, String dependencyTypeProperty,
+        String hardDependencyType, String parallelDeploymentsProperty) {
+        super(descriptor, handler, dependencyTypeProperty, hardDependencyType);
+        this.parallelDeploymentsProperty = parallelDeploymentsProperty;
+    }
+
+    @Override
+    public List<? extends Module> sort() {
+        DeploymentDescriptor descriptorV3 = cast(descriptor);
+        if (hasDeployedAfter(descriptorV3)) {
+            return sortUsingDeployedAfter();
+        }
+        return super.sort();
+    }
+
+    private boolean hasDeployedAfter(DeploymentDescriptor descriptorV3) {
+        return isParallelDeploymentsEnabled(descriptorV3) || hasDeployedAfterAttribute(descriptorV3);
+    }
+
+    private boolean isParallelDeploymentsEnabled(DeploymentDescriptor descriptor) {
+        return (Boolean) descriptor.getParameters()
+            .getOrDefault(parallelDeploymentsProperty, false);
+    }
+
+    private boolean hasDeployedAfterAttribute(DeploymentDescriptor descriptor) {
+        return descriptor.getModules3()
+            .stream()
+            .anyMatch(this::hasDeployedAfterAttribute);
+    }
+
+    private boolean hasDeployedAfterAttribute(Module module) {
+        com.sap.cloud.lm.sl.mta.model.v3.Module moduleV3 = cast(module);
+        return moduleV3.getDeployedAfter() != null;
+    }
+
+    @Override
+    protected ModuleDependenciesCollector getDependenciesCollector() {
+        return new ModuleDependenciesCollector(descriptor, handler);
+    }
+
+    private List<Module> sortUsingDeployedAfter() {
+        List<Module> modules = new ArrayList<>(getModules());
+        Collections.sort(modules, getModuleComparator());
+        return modules;
+    }
+
+    protected List<Module> getModules() {
+        DeploymentDescriptor descriptorV3 = cast(descriptor);
+        List<Module> modules = new ArrayList<>(descriptorV3.getModules3());
+        modules.stream()
+            .forEach(this::collectDependencies);
+        return modules;
+    }
+
+    protected void collectDependencies(Module module) {
+        getDependenciesCollectorSupportingDeployedAfter().collect(module);
+    }
+
+    private ModuleDependenciesCollector getDependenciesCollectorSupportingDeployedAfter() {
+        return new com.sap.cloud.lm.sl.mta.builders.v3.ModuleDependenciesCollector(descriptor);
+    }
+
+    protected Comparator getModuleComparator() {
+        return new ModuleComparator();
+    }
+
+}

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/Schemas.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/Schemas.java
@@ -51,6 +51,7 @@ public class Schemas extends com.sap.cloud.lm.sl.mta.handlers.v2.Schemas {
         MODULE.add("parameters-metadata", PROPERTIES);
         MODULE.add("requires", new ListElement(REQUIRED_DEPENDENCY));
         MODULE.add("provides", new ListElement(PROVIDED_DEPENDENCY));
+        MODULE.add("deployed-after", new ListElement(STRING));
 
         REQUIRED_DEPENDENCY.add("name", UNIQUE_MTA_IDENTIFIER);
         REQUIRED_DEPENDENCY.add("group", STRING);

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/message/Messages.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/message/Messages.java
@@ -40,6 +40,7 @@ public class Messages {
     public static final String UNSUPPORTED_VERSION = "Version \"{0}\" is not supported";
     public static final String COULD_NOT_FIND_REQUIRED_PROPERTY = "Could not find required property \"{0}\"";
     public static final String MULTIPLE_HARD_MODULES_DETECTED = "Modules, \"{0}\" and \"{1}\", have hard circular dependencies";
+    public static final String CIRCULAR_DEPLOYMENT_DEPENDENCIES_DETECTED = "Modules, \"{0}\" and \"{1}\", both depend on each others for deployment";
     public static final String ILLEGAL_REFERENCES_DETECTED = "Module \"{0}\" does not contain a required dependency for \"{1}\", but contains references to its properties";
     public static final String COULD_NOT_FIND_ELEMENT_IN_SCHEMA = "Could not find element \"{0}\" in schema for {1}";
     public static final String ERROR_PARSING_YAML_STREAM = "Error while parsing YAML stream";

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/Module.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/v3/Module.java
@@ -2,7 +2,9 @@ package com.sap.cloud.lm.sl.mta.model.v3;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.ObjectUtils;
 
@@ -28,6 +30,8 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
     @YamlElement(ModuleParser.PARAMETERS_METADATA)
     @YamlAdapter(MetadataConverter.class)
     private Metadata parametersMetadata;
+    @YamlElement(ModuleParser.DEPLOYED_AFTER)
+    private List<String> deployedAfter;
 
     protected Module() {
 
@@ -71,6 +75,10 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
         return providedDependencies3;
     }
 
+    public List<String> getDeployedAfter() {
+        return deployedAfter;
+    }
+
     public void setRequiredDependencies3(List<RequiredDependency> requiredDependencies) {
         setRequiredDependencies(requiredDependencies);
     }
@@ -87,6 +95,10 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
     @Override
     protected void setProvidedDependencies(List<? extends com.sap.cloud.lm.sl.mta.model.v1.ProvidedDependency> providedDependencies) {
         this.providedDependencies3 = ListUtil.cast(providedDependencies);
+    }
+
+    public void setDeployedAfter(List<String> deployedAfter) {
+        this.deployedAfter = deployedAfter;
     }
 
     @Override
@@ -110,6 +122,8 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
         result.setProvidedDependencies3(clonedProvidedDependencies);
         result.setParametersMetadata(getParametersMetadata());
         result.setPropertiesMetadata(getPropertiesMetadata());
+        List<String> clonedDeployedAfter = getDeployedAfter() != null ? new ArrayList<>(getDeployedAfter()) : null;
+        result.setDeployedAfter(clonedDeployedAfter);
         return result.build();
     }
 
@@ -119,6 +133,7 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
         protected List<ProvidedDependency> providedDependencies3;
         protected Metadata propertiesMetadata;
         protected Metadata parametersMetadata;
+        protected List<String> deployedAfter;
 
         @Override
         public Module build() {
@@ -129,12 +144,11 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
             result.setDescription(description);
             result.setProperties(ObjectUtils.defaultIfNull(properties, Collections.<String, Object> emptyMap()));
             result.setParameters(ObjectUtils.defaultIfNull(parameters, Collections.<String, Object> emptyMap()));
-            result.setRequiredDependencies3(
-                ObjectUtils.defaultIfNull(requiredDependencies3, Collections.<RequiredDependency> emptyList()));
-            result.setProvidedDependencies3(
-                ObjectUtils.defaultIfNull(providedDependencies3, Collections.<ProvidedDependency> emptyList()));
+            result.setRequiredDependencies3(ObjectUtils.defaultIfNull(requiredDependencies3, Collections.<RequiredDependency> emptyList()));
+            result.setProvidedDependencies3(ObjectUtils.defaultIfNull(providedDependencies3, Collections.<ProvidedDependency> emptyList()));
             result.setPropertiesMetadata(ObjectUtils.defaultIfNull(propertiesMetadata, Metadata.DEFAULT_METADATA));
             result.setParametersMetadata(ObjectUtils.defaultIfNull(parametersMetadata, Metadata.DEFAULT_METADATA));
+            result.setDeployedAfter(deployedAfter);
             return result;
         }
 
@@ -161,6 +175,10 @@ public class Module extends com.sap.cloud.lm.sl.mta.model.v2.Module
 
         public void setProvidedDependencies3(List<ProvidedDependency> providedDependencies) {
             setProvidedDependencies(providedDependencies);
+        }
+
+        public void setDeployedAfter(List<String> deployedAfter) {
+            this.deployedAfter = deployedAfter;
         }
 
     }

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/parsers/v3/ModuleParser.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/parsers/v3/ModuleParser.java
@@ -9,15 +9,16 @@ import com.sap.cloud.lm.sl.common.ParsingException;
 import com.sap.cloud.lm.sl.common.util.ListUtil;
 import com.sap.cloud.lm.sl.mta.model.Metadata;
 import com.sap.cloud.lm.sl.mta.model.v3.Module;
+import com.sap.cloud.lm.sl.mta.model.v3.Module.Builder;
 import com.sap.cloud.lm.sl.mta.model.v3.ProvidedDependency;
 import com.sap.cloud.lm.sl.mta.model.v3.RequiredDependency;
-import com.sap.cloud.lm.sl.mta.model.v3.Module.Builder;
 import com.sap.cloud.lm.sl.mta.schema.MapElement;
 
 public class ModuleParser extends com.sap.cloud.lm.sl.mta.parsers.v2.ModuleParser {
 
     public static final String PROPERTIES_METADATA = "properties-metadata";
     public static final String PARAMETERS_METADATA = "parameters-metadata";
+    public static final String DEPLOYED_AFTER = "deployed-after";
 
     public ModuleParser(Map<String, Object> source) {
         super(MODULE, source);
@@ -40,6 +41,7 @@ public class ModuleParser extends com.sap.cloud.lm.sl.mta.parsers.v2.ModuleParse
         builder.setParametersMetadata(getParametersMetadata());
         builder.setRequiredDependencies3(getRequiredDependencies3());
         builder.setProvidedDependencies3(getProvidedDependencies3());
+        builder.setDeployedAfter(getDeployedAfter());
         return builder.build();
     }
 
@@ -67,5 +69,9 @@ public class ModuleParser extends com.sap.cloud.lm.sl.mta.parsers.v2.ModuleParse
     @Override
     protected RequiredDependencyParser getRequiredDependencyParser(Map<String, Object> source) {
         return new RequiredDependencyParser(source); // v3
+    }
+
+    protected List<String> getDeployedAfter() {
+        return getListElement(DEPLOYED_AFTER);
     }
 }

--- a/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/v1/DescriptorHandlerTest.java
+++ b/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/v1/DescriptorHandlerTest.java
@@ -99,13 +99,14 @@ public class DescriptorHandlerTest {
     @RunWith(Parameterized.class)
     public static class DescriptorHandlerTest2 {
 
+        public static final String PARALLEL_DEPLOYMENTS_PROP = "parallel-deployments";
         public static final String DEPENDENCY_TYPE_PROP = "dependency-type";
         public static final String DEPENDENCY_TYPE_HARD = "hard";
 
-        private final DescriptorHandler handler = getDescriptorHandler();
+        protected final DescriptorHandler handler = getDescriptorHandler();
 
-        private String descriptorLocation;
-        private Expectation expectation;
+        protected String descriptorLocation;
+        protected Expectation expectation;
 
         public DescriptorHandlerTest2(String descriptorLocation, Expectation expectation) {
             this.descriptorLocation = descriptorLocation;
@@ -185,10 +186,10 @@ public class DescriptorHandlerTest {
 
                 @Override
                 public String call() throws Exception {
-                    return Arrays.toString(getNames(handler.getSortedModules(descriptor, DEPENDENCY_TYPE_PROP, DEPENDENCY_TYPE_HARD)));
+                    return Arrays.toString(getNames(handler.getModulesForDeployment(descriptor, PARALLEL_DEPLOYMENTS_PROP, DEPENDENCY_TYPE_PROP, DEPENDENCY_TYPE_HARD)));
                 }
 
-                private String[] getNames(List<Module> modulles) {
+                private String[] getNames(List<? extends Module> modulles) {
                     List<String> names = new LinkedList<>();
                     for (Module module : modulles) {
                         names.add(module.getName());

--- a/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/v3/DescriptorHandlerTest.java
+++ b/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/v3/DescriptorHandlerTest.java
@@ -1,0 +1,194 @@
+package com.sap.cloud.lm.sl.mta.handlers.v3;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.ListUtils;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.sap.cloud.lm.sl.common.util.Callable;
+import com.sap.cloud.lm.sl.common.util.CommonUtil;
+import com.sap.cloud.lm.sl.common.util.TestUtil;
+import com.sap.cloud.lm.sl.common.util.TestUtil.Expectation;
+import com.sap.cloud.lm.sl.common.util.TestUtil.Expectation.Type;
+import com.sap.cloud.lm.sl.mta.model.v1.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.v1.Module;
+
+@RunWith(Enclosed.class)
+public class DescriptorHandlerTest extends com.sap.cloud.lm.sl.mta.handlers.v2.DescriptorHandlerTest {
+
+    @RunWith(Parameterized.class)
+    public static class DescriptorHandlerSequentialTest2
+        extends com.sap.cloud.lm.sl.mta.handlers.v2.DescriptorHandlerTest.DescriptorHandlerTest2 {
+
+        public DescriptorHandlerSequentialTest2(String descriptorLocation, Expectation expectation) {
+            super(descriptorLocation, expectation);
+        }
+
+        protected DescriptorHandler getDescriptorHandler() {
+            return new DescriptorHandler();
+        }
+
+        @Parameters
+        public static Iterable<Object[]> getParameters() {
+            return Arrays.asList(new Object[][] {
+// @formatter:off
+                // (00)
+                {
+                    "mtad-05.yaml", new Expectation("[bar, foo, baz, qux]"),
+                },
+                // (01)
+                {
+                    "mtad-06.yaml", new Expectation("[bar, foo]"),
+                },
+                // (02)
+                {
+                    "mtad-07.yaml", new Expectation("[foo, bar]"),
+                },
+                // (03) The broker has a transitive dependency to the backend:
+                {
+                    "mtad-08.yaml", new Expectation("[db, service, backend, dashboard, broker]"),
+                },
+                // (04) There is a direct circular dependency between two modules, but  one of the modules  is soft:
+                {
+                    "mtad-09.yaml", new Expectation("[bar, baz, foo]"),
+                },
+                // (05) There is a direct circular dependency between two modules, and both of the modules are hard:
+                {
+                    "mtad-10.yaml", new Expectation(Type.EXCEPTION, "Modules, \"baz\" and \"foo\", have hard circular dependencies"),
+                },
+                // (06) There is a direct circular dependency between two modules, and both of the modules are soft:
+                {
+                    "mtad-13.yaml", new Expectation("[bar, foo, baz]"),
+                },
+                // (07) There is a circular transitive dependency between two modules, and both of the modules are hard:
+                {
+                    "mtad-11.yaml", new Expectation(Type.EXCEPTION, "Modules, \"baz\" and \"foo\", have hard circular dependencies"),
+                },
+                // (08) There is a circular transitive dependency between two modules, and both of the modules are hard:
+                {
+                    "mtad-14.yaml", new Expectation("[foo, bar, baz]"),
+                },
+                // (09) A module requires something from the same module:
+                {
+                    "mtad-12.yaml", new Expectation("[di-core-db, di-local-npm-registry, di-core, di-builder, di-runner]"),
+                },
+                // (10) There are two circular dependencies and all modules are soft:
+                {
+                    "mtad-15.yaml", new Expectation("[foo, bar, baz, qux, quux]"),
+                },
+                // (11) There are two circular dependencies and two modules are hard:
+                {
+                    "mtad-16.yaml", new Expectation(Type.EXCEPTION, "Modules, \"baz\" and \"bar\", have hard circular dependencies"),
+                },
+                // (12) There are two circular dependencies and one  module  is hard:
+                {
+                    "mtad-17.yaml", new Expectation("[bar, foo, baz, qux, quux]"),
+                },
+                // (13) There is a hard circular dependency between a module and itself:
+                {
+                    "mtad-18.yaml", new Expectation("[bar, foo]"),
+                },
+                // (14) The deployed-after attribute is used, therefore requires section is not used:
+                {
+                    "mtad-05-deployed-after.yaml", new Expectation("[baz, bar, foo, qux]"),
+                },
+// @formatter:on
+            });
+        }
+
+        @Override
+        protected DescriptorParser getDescriptorParser() {
+            return new DescriptorParser();
+        }
+
+    }
+
+    @RunWith(Parameterized.class)
+    public static class DescriptorHandlerParallelTest2
+        extends com.sap.cloud.lm.sl.mta.handlers.v2.DescriptorHandlerTest.DescriptorHandlerTest2 {
+
+        public DescriptorHandlerParallelTest2(String descriptorLocation, Expectation expectation) {
+            super(descriptorLocation, expectation);
+        }
+
+        protected DescriptorHandler getDescriptorHandler() {
+            return new DescriptorHandler();
+        }
+
+        @Parameters
+        public static Iterable<Object[]> getParameters() {
+            return Arrays.asList(new Object[][] {
+// @formatter:off
+                // (00)
+                {
+                    "mtad-05-deployed-after-with-parallel-deployments.yaml", new Expectation("{bar=[], foo=[bar], baz=[foo, bar], qux=[]}"),
+                },
+                // (01)
+                {
+                    "mtad-06-deployed-after-with-parallel-deployments.yaml", new Expectation("{bar=[], foo=[bar]}"),
+                },
+                // (02)
+                {
+                    "mtad-07-deployed-after-with-parallel-deployments.yaml", new Expectation("{foo=[], bar=[foo]}"),
+                },
+                // (03) The broker has a transitive dependency to the backend:
+                {
+                    "mtad-08-deployed-after-with-parallel-deployments.yaml", new Expectation("{db=[], service=[db], backend=[], dashboard=[service, db, backend], broker=[dashboard, service, db, backend]}"),
+                },
+                // (05) Circular dependencies
+                {
+                    "mtad-10-deployed-after-with-parallel-deployments.yaml", new Expectation(Type.EXCEPTION, "Modules, \"baz\" and \"foo\", both depend on each others for deployment"),
+                },
+                // (07) Circular transistive dependencies
+                {
+                    "mtad-11-deployed-after-with-parallel-deployments.yaml", new Expectation(Type.EXCEPTION, "Modules, \"bar\" and \"foo\", both depend on each others for deployment"),
+                },
+                // (13) A module depends on itself
+                {
+                    "mtad-18-deployed-after-with-parallel-deployments.yaml", new Expectation("{bar=[], foo=[bar]}"),
+                },
+// @formatter:on
+            });
+        }
+
+        @Override
+        @Test
+        public void testGetSortedModules() throws Exception {
+            final DeploymentDescriptor descriptor = getDescriptorParser()
+                .parseDeploymentDescriptorYaml(TestUtil.getResourceAsString(descriptorLocation, getClass()));
+
+            TestUtil.test(new Callable<String>() {
+
+                @Override
+                public String call() throws Exception {
+                    return getDeployedAfterMapString(
+                        handler.getModulesForDeployment(descriptor, PARALLEL_DEPLOYMENTS_PROP, DEPENDENCY_TYPE_PROP, DEPENDENCY_TYPE_HARD));
+                }
+
+                private String getDeployedAfterMapString(List<? extends Module> modulles) {
+                    Map<String, List<String>> deployedAfterMap = new LinkedHashMap<>();
+                    for (Module module : modulles) {
+                        com.sap.cloud.lm.sl.mta.model.v3.Module moduleV3 = CommonUtil.cast(module);
+                        deployedAfterMap.put(moduleV3.getName(), ListUtils.emptyIfNull(moduleV3.getDeployedAfter()));
+                    }
+                    return deployedAfterMap.toString();
+                }
+
+            }, expectation, getClass());
+        }
+
+        @Override
+        protected DescriptorParser getDescriptorParser() {
+            return new DescriptorParser();
+        }
+
+    }
+
+}

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-00.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-00.yaml
@@ -30,6 +30,7 @@ modules:
       domain: bestprice.sap.com
       version-number: '7.20'    # because this is a floating-point number it would resolve into 7.2 which is mathematically the same; to avoid this unwanted behavior explicitly declare it as string with surrounding single quotes
       version-tag: v7.20        # because of the letter 'v' the value type is identified as string 
+    deployed-after: [pricing]
 
   - name: pricing
     type: org.nodejs
@@ -57,6 +58,7 @@ modules:
           url: ~{url}
           application-key: ~{application-key}
           secret-key: ~{secret-key}
+    deployed-after: [pricing-db]
 
   - name: pricing-db
     type: com.sap.hana.hdi

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-01.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-01.yaml
@@ -51,6 +51,7 @@ modules:
       overwritable: false
     domain:
       optional: true
+  deployed-after: [pricing]
 - name: pricing
   type: org.nodejs
   properties:
@@ -81,6 +82,7 @@ modules:
       url: ~{url}
       application-key: ~{application-key}
       secret-key: ~{secret-key}
+  deployed-after: [pricing-db]
 - name: pricing-db
   type: com.sap.hana.hdi
   properties:

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-05-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-05-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,20 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: foo
+    type: foo
+    deployed-after: [foo, bar]
+
+  - name: bar
+    type: bar
+
+  - name: baz
+    type: baz
+    deployed-after: [foo]
+
+  - name: qux
+    type: qux

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-05-deployed-after.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-05-deployed-after.yaml
@@ -1,0 +1,20 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    deployed-after: [foo, bar, baz]
+
+  - name: bar
+    type: bar
+    deployed-after: [baz]
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+
+  - name: qux
+    type: qux

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-05.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-05.yaml
@@ -1,0 +1,22 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: foo
+      - name: bar
+      - name: baz
+
+  - name: bar
+    type: bar
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+
+  - name: qux
+    type: qux

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-06-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-06-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,13 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: foo
+    type: foo
+    deployed-after: [bar]
+
+  - name: bar
+    type: bar

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-06.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-06.yaml
@@ -1,0 +1,12 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: bar
+
+  - name: bar
+    type: bar

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-07-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-07-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,13 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: foo
+    type: foo
+
+  - name: bar
+    type: bar
+    deployed-after: [foo]

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-07.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-07.yaml
@@ -1,0 +1,12 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+
+  - name: bar
+    type: bar
+    requires:
+      - name: foo

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-08-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-08-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,24 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: db
+    type: com.sap.xs.hdi
+
+  - name: service
+    type: javascript.nodejs
+    deployed-after: [db]
+
+  - name: broker
+    type: javascript.nodejs
+    deployed-after: [dashboard, db, service]
+
+  - name: backend
+    type: javascript.nodejs
+
+  - name: dashboard
+    type: javascript.nodejs
+    deployed-after: [service, db, backend]

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-08.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-08.yaml
@@ -1,0 +1,29 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: db
+    type: com.sap.xs.hdi
+
+  - name: service
+    type: javascript.nodejs
+    requires:
+      - name: db
+
+  - name: broker
+    type: javascript.nodejs
+    requires:
+      - name: dashboard
+      - name: db
+      - name: service
+
+  - name: backend
+    type: javascript.nodejs
+
+  - name: dashboard
+    type: javascript.nodejs
+    requires:
+      - name: service
+      - name: db
+      - name: backend

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-09.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-09.yaml
@@ -1,0 +1,22 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: bar
+      - name: baz
+    parameters:
+      dependency-type: soft
+
+  - name: bar
+    type: bar
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+    parameters:
+      dependency-type: hard

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-10-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-10-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,17 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: foo
+    type: foo
+    deployed-after: [bar, baz]
+
+  - name: bar
+    type: bar
+
+  - name: baz
+    type: baz
+    deployed-after: [foo]

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-10.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-10.yaml
@@ -1,0 +1,22 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: bar
+      - name: baz
+    parameters:
+      dependency-type: hard
+
+  - name: bar
+    type: bar
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+    parameters:
+      dependency-type: hard

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-11-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-11-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,18 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: foo
+    type: foo
+    deployed-after: [bar]
+
+  - name: bar
+    type: bar
+    deployed-after: [baz]
+
+  - name: baz
+    type: baz
+    deployed-after: [foo]

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-11.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-11.yaml
@@ -1,0 +1,25 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: bar
+    parameters:
+      dependency-type: hard
+
+  - name: bar
+    type: bar
+    requires:
+      - name: baz
+    parameters:
+      dependency-type: soft
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+    parameters:
+      dependency-type: hard

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-12.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-12.yaml
@@ -1,0 +1,62 @@
+_schema-version: "3"
+ID: com.sap.devx.di
+version: 3.1612.2
+
+modules:
+    - name: di-core-db
+      type: foo
+      requires:
+        - name: di-core-hdi
+
+    - name: di-local-npm-registry
+      type: foo
+      provides:
+        - name: local-npm-repository
+      requires:
+        - name: devx-npm-cache-fs
+
+    - name: di-core
+      type: foo
+      provides:
+        - name: di-core-genbuilder-buildpack
+        - name: di-core-url
+      requires:
+        - name: devx-uaa
+        - name: di-core-hdi
+        - name: devx-fs
+        - name: di-dev-space
+        - name: di-core-url
+        - name: xs-endpoint
+        - name: di-core-db
+
+    - name: di-builder
+      type: foo
+      requires:
+        - name: di-core-genbuilder-buildpack
+        - name: di-dev-space
+        - name: local-npm-repository
+        - name: xs-endpoint
+        - name: di-core-url
+        - name: devx-uaa
+
+    - name: di-runner
+      type: foo
+      requires:
+        - name: local-npm-repository
+        - name: di-dev-space
+        - name: di-core-url
+        - name: xs-endpoint
+        - name: devx-uaa
+
+resources:
+    - name: devx-npm-cache-fs
+    
+    - name: devx-uaa
+
+    - name: di-dev-space
+
+    - name: di-core-hdi
+
+    - name: xs-endpoint
+
+    - name: devx-fs

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-13.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-13.yaml
@@ -1,0 +1,22 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: bar
+      - name: baz
+    parameters:
+      dependency-type: soft
+
+  - name: bar
+    type: bar
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+    parameters:
+      dependency-type: soft

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-14.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-14.yaml
@@ -1,0 +1,25 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: bar
+    parameters:
+      dependency-type: soft
+
+  - name: bar
+    type: bar
+    requires:
+      - name: baz
+    parameters:
+      dependency-type: soft
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+    parameters:
+      dependency-type: soft

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-15.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-15.yaml
@@ -1,0 +1,29 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: foo
+      - name: bar
+      - name: baz
+
+  - name: bar
+    type: bar
+    requires:
+      - name: qux
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+
+  - name: qux
+    type: qux
+    requires:
+      - name: foo
+
+  - name: quux
+    type: quux

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-16.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-16.yaml
@@ -1,0 +1,33 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: foo
+      - name: bar
+      - name: baz
+
+  - name: bar
+    type: bar
+    requires:
+      - name: qux
+    parameters:
+      dependency-type: hard
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+    parameters:
+      dependency-type: hard
+
+  - name: qux
+    type: qux
+    requires:
+      - name: foo
+
+  - name: quux
+    type: quux

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-17.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-17.yaml
@@ -1,0 +1,31 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: foo
+      - name: bar
+      - name: baz
+
+  - name: bar
+    type: bar
+    requires:
+      - name: qux
+    parameters:
+      dependency-type: hard
+
+  - name: baz
+    type: baz
+    requires:
+      - name: foo
+
+  - name: qux
+    type: qux
+    requires:
+      - name: foo
+
+  - name: quux
+    type: quux

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-18-deployed-after-with-parallel-deployments.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-18-deployed-after-with-parallel-deployments.yaml
@@ -1,0 +1,13 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+parameters:
+  parallel-deployments: true
+
+modules:
+  - name: foo
+    type: foo
+    deployed-after: [foo, bar]
+
+  - name: bar
+    type: bar

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-18.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/mtad-18.yaml
@@ -1,0 +1,15 @@
+_schema-version: 3
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: foo
+    type: foo
+    requires:
+      - name: foo
+      - name: bar
+    parameters:
+      dependency-type: hard
+
+  - name: bar
+    type: bar

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/parsed-mtad-00.json
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/parsed-mtad-00.json
@@ -65,6 +65,9 @@
       "parametersMetadata": {
         "metadata": {}
       },
+      "deployedAfter": [
+        "pricing"
+      ],
       "path": "web-server/",
       "parameters": {
         "host": "www",
@@ -158,6 +161,9 @@
       "parametersMetadata": {
         "metadata": {}
       },
+      "deployedAfter": [
+        "pricing-db"
+      ],
       "parameters": {
         "host": "api",
         "domain": "bestprice.sap.com"

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/parsed-mtad-01.json
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/v3/parsed-mtad-01.json
@@ -92,6 +92,9 @@
           }
         }
       },
+      "deployedAfter": [
+        "pricing"
+      ],
       "path": "web-server/",
       "parameters": {
         "domain": "bestprice.sap.com",
@@ -189,6 +192,9 @@
       "parametersMetadata": {
         "metadata": {}
       },
+      "deployedAfter": [
+        "pricing-db"
+      ],
       "parameters": {
         "host": "api",
         "domain": "bestprice.sap.com"


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
Introduces the new schema element 'deployed-after' which is to be used in spec version 3.2 and allows implementation of parallel deployments.

LMCROSSITXSADEPLOY-24