### PR TITLE
downgrade gson to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <jax-rs.version>2.0.1</jax-rs.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <gson.version>2.8.5</gson.version>
+        <gson.version>2.6.2</gson.version>
         <snakeyaml.version>1.23</snakeyaml.version>
         <semver4j.version>2.2.0</semver4j.version>
     </properties>


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
Downgrade gson to 2.6.2 because newer version cause a conflict with the
jclouds library that is used to operate the objectstore.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
LMCROSSITXSADEPLOY-1257
