### PR TITLE
VersionRule.value(caseInsensitive)

### DIFF
--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/VersionRule.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/model/VersionRule.java
@@ -37,4 +37,7 @@ public enum VersionRule {
         return versionRuleValidator.allows(deploymentType);
     }
 
+    public static VersionRule value(String caseInsensitiveValue) {
+        return VersionRule.valueOf(caseInsensitiveValue.toUpperCase());
+    }
 }


### PR DESCRIPTION
#### Description: 
the version rule parameter currently accepts only all caps values, which is not very usable 
