### PR TITLE
fix plural params to override singular

### DIFF
--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/util/PropertiesUtil.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/util/PropertiesUtil.java
@@ -123,15 +123,16 @@ public class PropertiesUtil {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> List<T> getAll(List<Map<String, Object>> propertiesList, String single, String plural) {
+    public static <T> List<T> getPluralOrSingular(List<Map<String, Object>> propertiesList, String plural, String single) {
         List<T> result = new ArrayList<>();
-        T value = (T) getPropertyValue(propertiesList, single, null);
         List<T> values = (List<T>) getPropertyValue(propertiesList, plural, null);
-        if (value != null) {
-            result.add(value);
-        }
         if (values != null) {
             result.addAll(values);
+            return result;
+        }
+        T value = (T) getPropertyValue(propertiesList, single, null);
+        if (value != null) {
+            result.add(value);
         }
         return result;
     }


### PR DESCRIPTION
#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
this fixes the bug with host/hosts and domain/domains where the plural
parameter was merged with the singular, causing non-specified
hosts/domains to appear for apps with only the plural parameter defined.

#### Issue: <!-- Link to a Github Issue, delete if not applicable -->
Bug: LMCROSSITXSADEPLOY-1558
