### PR TITLE
Throw good error message for emtpy extension/deployment descriptors

### DIFF
--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/DescriptorParserFacade.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/DescriptorParserFacade.java
@@ -26,6 +26,9 @@ public class DescriptorParserFacade {
     }
 
     private DeploymentDescriptor parseDeploymentDescriptor(Map<String, Object> descriptor) {
+        if (descriptor == null) {
+            throw new ContentException(Messages.ERROR_EMPTY_DEPLOYMENT_DESCRIPTOR);
+        }
         DescriptorParser parser = getDescriptorParser(descriptor);
         return parser.parseDeploymentDescriptor(descriptor);
     }
@@ -41,6 +44,9 @@ public class DescriptorParserFacade {
     }
 
     private ExtensionDescriptor parseExtensionDescriptor(Map<String, Object> descriptor) {
+        if (descriptor == null) {
+            throw new ContentException(Messages.ERROR_EMPTY_EXTENSION_DESCRIPTOR);
+        }
         DescriptorParser parser = getDescriptorParser(descriptor);
         return parser.parseExtensionDescriptor(descriptor);
     }

--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/message/Messages.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/message/Messages.java
@@ -26,6 +26,8 @@ public class Messages {
     public static final String ERROR_RETRIEVING_ARCHIVE_ENTRY = "Error while retrieving archive entry \"{0}\"";
     public static final String NULL_VALUE_FOR_KEY = "Null value for key \"{0}\"";
     public static final String MISSING_REQUIRED_KEY = "Missing required key \"{0}\"";
+    public static final String ERROR_EMPTY_DEPLOYMENT_DESCRIPTOR = "Empty deployment descriptor";
+    public static final String ERROR_EMPTY_EXTENSION_DESCRIPTOR = "Empty extension descriptor";
     public static final String NULL_CONTENT = "Null content";
     public static final String INVALID_CONTENT_TYPE = "Invalid content type, expected \"{0}\" but got \"{1}\"";
     public static final String INVALID_TYPE_FOR_KEY = "Invalid type for key \"{0}\", expected \"{1}\" but got \"{2}\"";

--- a/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/DescriptorParserFacadeTest.java
+++ b/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/DescriptorParserFacadeTest.java
@@ -1,0 +1,90 @@
+package com.sap.cloud.lm.sl.mta.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.InputStream;
+import java.text.MessageFormat;
+
+import org.junit.Test;
+
+import com.sap.cloud.lm.sl.common.ContentException;
+import com.sap.cloud.lm.sl.common.util.TestUtil;
+import com.sap.cloud.lm.sl.mta.message.Messages;
+import com.sap.cloud.lm.sl.mta.model.DeploymentDescriptor;
+import com.sap.cloud.lm.sl.mta.model.ExtensionDescriptor;
+
+public class DescriptorParserFacadeTest {
+
+    private static final String MTAD_VALID = "mtad-valid.yaml";
+    private static final String DESCRIPTOR_EMPTY = "empty.yaml";
+    private static final String MTAEXT_VALID = "config-valid.mtaext";
+    private static final String DESCRIPTOR_MISSING_SCHEMA = "mtad-missing-schema.yaml";
+
+    private static final String SCHEMA_VERSION_KEY = "_schema-version";
+
+    DescriptorParserFacade parser = new DescriptorParserFacade();
+
+    @Test
+    public void testValidParseDeploymentDescriptorWithStream() {
+        InputStream descriptorStream = TestUtil.getResourceAsInputStream(MTAD_VALID, getClass());
+        DeploymentDescriptor descriptor = parser.parseDeploymentDescriptor(descriptorStream);
+        assertNotNull(descriptor);
+    }
+
+    @Test
+    public void testValidParseDeploymentDescriptorWithString() {
+        String descriptorString = TestUtil.getResourceAsString(MTAD_VALID, getClass());
+        DeploymentDescriptor descriptor = parser.parseDeploymentDescriptor(descriptorString);
+        assertNotNull(descriptor);
+    }
+
+    @Test
+    public void testEmptyParseDeploymentDescriptorWithStream() {
+        InputStream descriptorStream = TestUtil.getResourceAsInputStream(DESCRIPTOR_EMPTY, getClass());
+        try {
+            parser.parseDeploymentDescriptor(descriptorStream);
+            fail("Expected exception");
+        } catch (ContentException e) {
+            assertEquals(Messages.ERROR_EMPTY_DEPLOYMENT_DESCRIPTOR, e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMissingSchemaParseDeploymentDescriptorWithStream() {
+        InputStream descriptorStream = TestUtil.getResourceAsInputStream(DESCRIPTOR_MISSING_SCHEMA, getClass());
+        try {
+            parser.parseDeploymentDescriptor(descriptorStream);
+            fail("Expected exception");
+        } catch (ContentException e) {
+            assertEquals(MessageFormat.format(Messages.MISSING_REQUIRED_KEY, SCHEMA_VERSION_KEY), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testValidParseExtensiontDescriptorWithStream() {
+        InputStream descriptorStream = TestUtil.getResourceAsInputStream(MTAEXT_VALID, getClass());
+        ExtensionDescriptor descriptor = parser.parseExtensionDescriptor(descriptorStream);
+        assertNotNull(descriptor);
+    }
+
+    @Test
+    public void testValidParseExtensionDescriptorWithString() {
+        String descriptorString = TestUtil.getResourceAsString(MTAEXT_VALID, getClass());
+        ExtensionDescriptor descriptor = parser.parseExtensionDescriptor(descriptorString);
+        assertNotNull(descriptor);
+    }
+
+    @Test
+    public void testEmptyParseExtensionDescriptorWithString() {
+        InputStream descriptorStream = TestUtil.getResourceAsInputStream(DESCRIPTOR_EMPTY, getClass());
+        try {
+            parser.parseExtensionDescriptor(descriptorStream);
+            fail("Expected exception");
+        } catch (ContentException e) {
+            assertEquals(Messages.ERROR_EMPTY_EXTENSION_DESCRIPTOR, e.getMessage());
+        }
+    }
+
+}

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/config-valid.mtaext
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/config-valid.mtaext
@@ -1,0 +1,3 @@
+_schema-version: 1.0.0
+ID: com.sap.mta.test.config-05
+extends: com.sap.mta.test

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/mtad-missing-schema.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/mtad-missing-schema.yaml
@@ -1,0 +1,2 @@
+ID: com.sap.mta.test
+version: 1.0.0

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/mtad-valid.yaml
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/mtad-valid.yaml
@@ -1,0 +1,7 @@
+_schema-version: "3.1.0"
+ID: com.sap.mta.test
+version: 1.0.0
+
+modules:
+  - name: anatz
+    type: java.tomcat


### PR DESCRIPTION
#### Description: 
When one uses emtpy file as extension descriptor, NPE occurs:
java.lang.NullPointerException: while trying to invoke the method java.util.Map.get(java.lang.Object) of a null object loaded from local variable 'descriptor'

Replace throwing NullPointerException with more meaningful error message

#### Issue: LMCROSSITXSADEPLOY-1604

