### PR TITLE
Increase version of Junit to 5.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.3.1</junit.version>
-        <junit.platform.version>1.3.1</junit.platform.version>
+        <junit.version>5.5.1</junit.version>
+        <junit.platform.version>1.5.1</junit.platform.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.9.5</mockito.version>
         <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>


### PR DESCRIPTION
This change allows you to run junit5 tests in latest version of Eclipse 2019-06