### PR TITLE
Add dedicated validation schema for v3 MTAEXT

### DIFF
--- a/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/Schemas.java
+++ b/com.sap.cloud.lm.sl.mta/src/main/java/com/sap/cloud/lm/sl/mta/handlers/v3/Schemas.java
@@ -13,6 +13,10 @@ public class Schemas extends com.sap.cloud.lm.sl.mta.handlers.v2.Schemas {
     public static final MapElement RESOURCE = new MapElement();
     public static final MapElement HOOK = new MapElement();
 
+    public static final MapElement MTAEXT = new MapElement();
+    public static final MapElement EXT_MODULE = new MapElement();
+    public static final MapElement EXT_REQUIRED_DEPENDENCY = new MapElement();
+    public static final MapElement EXT_PROVIDED_DEPENDENCY = new MapElement();
     public static final MapElement EXT_RESOURCE = new MapElement();
     public static final MapElement EXT_HOOK = new MapElement();
 
@@ -75,6 +79,27 @@ public class Schemas extends com.sap.cloud.lm.sl.mta.handlers.v2.Schemas {
         RESOURCE.add("properties-metadata", PROPERTIES);
         RESOURCE.add("parameters-metadata", PROPERTIES);
         RESOURCE.add("requires", new ListElement(RESOURCE_REQUIRED_DEPENDENCY));
+
+        MTAEXT.add("_schema-version", OBJECT_REQUIRED);
+        MTAEXT.add("ID", NON_UNIQUE_MTA_IDENTIFIER);
+        MTAEXT.add("extends", STRING_REQUIRED);
+        MTAEXT.add("modules", new ListElement(EXT_MODULE));
+        MTAEXT.add("resources", new ListElement(EXT_RESOURCE));
+        MTAEXT.add("parameters", PROPERTIES);
+
+        EXT_MODULE.add("name", UNIQUE_MTA_IDENTIFIER);
+        EXT_MODULE.add("properties", PROPERTIES);
+        EXT_MODULE.add("parameters", PROPERTIES);
+        EXT_MODULE.add("requires", new ListElement(EXT_REQUIRED_DEPENDENCY));
+        EXT_MODULE.add("provides", new ListElement(EXT_PROVIDED_DEPENDENCY));
+
+        EXT_PROVIDED_DEPENDENCY.add("name", UNIQUE_MTA_IDENTIFIER);
+        EXT_PROVIDED_DEPENDENCY.add("properties", PROPERTIES);
+        EXT_PROVIDED_DEPENDENCY.add("parameters", PROPERTIES);
+
+        EXT_REQUIRED_DEPENDENCY.add("name", UNIQUE_MTA_IDENTIFIER);
+        EXT_REQUIRED_DEPENDENCY.add("properties", PROPERTIES);
+        EXT_REQUIRED_DEPENDENCY.add("parameters", PROPERTIES);
 
         EXT_RESOURCE.add("name", UNIQUE_MTA_IDENTIFIER);
         EXT_RESOURCE.add("active", BOOLEAN);

--- a/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/DescriptorParserFacadeTest.java
+++ b/com.sap.cloud.lm.sl.mta/src/test/java/com/sap/cloud/lm/sl/mta/handlers/DescriptorParserFacadeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.InputStream;
 import java.text.MessageFormat;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -21,6 +22,7 @@ public class DescriptorParserFacadeTest {
     private static final String DESCRIPTOR_EMPTY = "empty.yaml";
     private static final String MTAEXT_VALID = "config-valid.mtaext";
     private static final String DESCRIPTOR_MISSING_SCHEMA = "mtad-missing-schema.yaml";
+    private static final String INVALID_RESOURCES_MTAEXT = "config-invalid-resources.mtaext";
 
     private static final String SCHEMA_VERSION_KEY = "_schema-version";
 
@@ -67,6 +69,18 @@ public class DescriptorParserFacadeTest {
         InputStream descriptorStream = TestUtil.getResourceAsInputStream(MTAEXT_VALID, getClass());
         ExtensionDescriptor descriptor = parser.parseExtensionDescriptor(descriptorStream);
         assertNotNull(descriptor);
+    }
+
+    @Test
+    public void testInvalidResourcesInExtensionDescriptor() {
+        InputStream descriptorStream = TestUtil.getResourceAsInputStream(INVALID_RESOURCES_MTAEXT, getClass());
+        try {
+            parser.parseExtensionDescriptor(descriptorStream);
+            fail("Expected exception");
+        } catch (ContentException e) {
+            assertEquals(MessageFormat.format(Messages.INVALID_TYPE_FOR_KEY, "resources#0#requires#0", Map.class.getSimpleName(),
+                         String.class.getSimpleName()), e.getMessage());
+        }
     }
 
     @Test

--- a/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/config-invalid-resources.mtaext
+++ b/com.sap.cloud.lm.sl.mta/src/test/resources/com/sap/cloud/lm/sl/mta/handlers/config-invalid-resources.mtaext
@@ -1,0 +1,11 @@
+_schema-version: 3.3.0
+ID: my-mta-dev
+extends: my-mta
+version: 1.0.0
+
+resources:
+  - name: my-service
+    parameters:
+      service-plan: "lite"
+    requires:
+    - my-ups # invalid schema


### PR DESCRIPTION
Fix shadowing bug by adding dedicated static
blocks for v3 MTAEXT validation schema.
JIRA: LMCROSSITXSADEPLOY-1936
